### PR TITLE
Do not restrict numpy to '<1.18'.

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -19,7 +19,7 @@ graphviz~=0.13
 ipython~=7.0
 jinja2~=2.10
 kiwipy[rmq]~=0.5.1
-numpy<1.18,~=1.17
+numpy~=1.17
 paramiko~=2.6
 pg8000~=1.13
 pgtest>=1.3.1,~=1.3

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
 - ipython~=7.0
 - jinja2~=2.10
 - kiwipy[rmq]~=0.5.1
-- numpy<1.18,~=1.17
+- numpy~=1.17
 - paramiko~=2.6
 - pika~=1.1
 - plumpy~=0.14.5

--- a/setup.json
+++ b/setup.json
@@ -33,7 +33,7 @@
     "ipython~=7.0",
     "jinja2~=2.10",
     "kiwipy[rmq]~=0.5.1",
-    "numpy~=1.17,<1.18",
+    "numpy~=1.17",
     "paramiko~=2.6",
     "pika~=1.1",
     "plumpy~=0.14.5",


### PR DESCRIPTION
Previous issues with the broken release should be resolved now.